### PR TITLE
Support synchronously metrics publishing

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -1,0 +1,25 @@
+name: Pull Request CI (Snapshot)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build.yml
+
+  event_file:
+    needs: build
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: Event File
+          path: ${{ github.event_path }}

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - "Branch CI (Snapshot)"
+      - "Pull Request CI (Snapshot)"
     types:
       - completed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the AWS SDK Java OpenTelemetry Metrics library.
 
-[1.0.1]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/pull/18
+[1.0.1]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/compare/aws-sdk-java-opentelemetry-metrics-1.0.0...aws-sdk-java-opentelemetry-metrics-1.0.1
 
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0
+[1.0.0]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/releases/tag/aws-sdk-java-opentelemetry-metrics-1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-09-19
+
+### Changed
+
+- Support for a null `executor`, allowing for synchronous metrics publishing.
+- Verify `openTelemetry` and `metricPrefix` are not null in the `OtelMetricPublisher` constructor.
+
 ## [1.0.0] - 2024-09-17
 
 ### Added
 
 - Initial release of the AWS SDK Java OpenTelemetry Metrics library.
+
+[1.0.1]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/pull/18
 
 [1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0

--- a/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
+++ b/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.metrics.MetricRecord;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
@@ -45,6 +46,13 @@ public class OtelMetricPublisher implements MetricPublisher {
     }
 
     public OtelMetricPublisher(OpenTelemetry openTelemetry, String metricPrefix, Executor executor) {
+        Objects.requireNonNull(metricPrefix, "metricPrefix must not be null");
+        Objects.requireNonNull(openTelemetry, "openTelemetry must not be null");
+
+        if (executor == null) {
+            log.warn("An executor is not provided. The metrics will be published synchronously on the calling thread.");
+        }
+
         this.metricPrefix = metricPrefix + ".";
         this.executor = executor;
 
@@ -57,6 +65,11 @@ public class OtelMetricPublisher implements MetricPublisher {
 
     @Override
     public void publish(MetricCollection metricCollection) {
+        if (executor == null) {
+            publishInternal(metricCollection);
+            return;
+        }
+
         try {
             executor.execute(() -> publishInternal(metricCollection));
         } catch (RejectedExecutionException ex) {


### PR DESCRIPTION
### Changed

- Support for a null `executor`, allowing for synchronous metrics publishing.
- Verify `openTelemetry` and `metricPrefix` are not null in the `OtelMetricPublisher` constructor.