### PR TITLE
Add default dimensions for OTEL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-02-10
+
+### Added
+
+- Add default dimensions for OTEL metrics.
+
 ## [1.0.1] - 2024-09-19
 
 ### Changed
@@ -17,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of the AWS SDK Java OpenTelemetry Metrics library.
+
+[1.1.0]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/compare/aws-sdk-java-opentelemetry-metrics-1.0.1...aws-sdk-java-opentelemetry-metrics-1.1.0
 
 [1.0.1]: https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics/compare/aws-sdk-java-opentelemetry-metrics-1.0.0...aws-sdk-java-opentelemetry-metrics-1.0.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.appsflyer</groupId>
     <artifactId>aws-sdk-java-opentelemetry-metrics</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>AWS SDK Java OpenTelemetry Metrics</name>
     <description>OpenTelemetry Metric Publisher for AWS SDK for Java</description>
     <url>https://github.com/AppsFlyer/aws-sdk-java-opentelemetry-metrics</url>

--- a/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
+++ b/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
@@ -60,7 +60,6 @@ public class OtelMetricPublisher implements MetricPublisher {
         if (executor == null) {
             log.warn("An executor is not provided. The metrics will be published synchronously on the calling thread.");
         }
-
         this.metricPrefix = metricPrefix + ".";
         this.executor = executor;
         this.baseAttributes = baseAttributes;

--- a/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
+++ b/src/main/java/com/appsflyer/otelawsmetrics/OtelMetricPublisher.java
@@ -52,7 +52,6 @@ public class OtelMetricPublisher implements MetricPublisher {
 
     public OtelMetricPublisher(OpenTelemetry openTelemetry, String metricPrefix,
                                Executor executor, Attributes baseAttributes) {
-
         Objects.requireNonNull(metricPrefix, "metricPrefix must not be null");
         Objects.requireNonNull(openTelemetry, "openTelemetry must not be null");
         Objects.requireNonNull(baseAttributes, "baseAttributes must not be null");


### PR DESCRIPTION
This allows one to add a number of custom dimensions to the published metrics. This may be necessary in order to analyze metrics along various dimensions, e.g. when exporting metrics to CloudWatch.